### PR TITLE
Initialize skinview plugin skeleton with anti-binary policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+* text=auto eol=lf
+
+# Toujours texte
+*.yml  text
+*.yaml text
+*.java text
+*.kt   text
+*.kts  text
+*.gradle text
+*.md   text
+*.properties text
+*.gitignore text
+*.gitattributes text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Gradle / IDE
+.gradle/
+build/
+out/
+.idea/
+*.iml
+
+# Binaires & artefacts (interdits au repo)
+*.jar
+*.class
+*.war
+*.ear
+*.zip
+*.7z
+*.rar
+*.pdf
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.webp
+*.ico
+*.exe
+*.dll
+*.so
+*.dylib
+*.bin
+*.dat
+*.mp3
+*.wav
+*.mp4
+*.mov
+*.avi
+*.mkv
+
+# OS
+.DS_Store
+Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+## 0.1.0
+- Initialisation du projet skinview (Heneria)
+- Gradle Kotlin DSL (Java 21), Paper API 1.21.x
+- Politique ANTI-BINAIRES: .gitignore, .gitattributes, tâche Gradle `checkNoBinaries`
+- `plugin.yml`, `config.yml`, `messages.yml`
+- Commande `/skinview` (help/reload) + tab-complete
+- Listeners (join/interact), logs de boot, fail-fast si commande absente
+How-to (build, config, commandes, permissions)
+Build (Java 21)
+
+```bash
+./gradlew clean check
+./gradlew build
+```
+
+Commandes
+
+/skinview help (toujours return true, pas d’écho)
+
+/skinview reload (perm skinview.admin)
+
+Permissions
+
+skinview.use, skinview.admin
+
+Validation (tests manuels)
+./gradlew clean check : doit passer sans lister de binaires.
+
+Démarrage serveur : plugin Enabled, aucun WARN/stacktrace.
+
+/skinview ou /skinview help : affiche l’aide (pas d’“usage”).
+
+/skinview reload : recharge config/messages.
+
+Tab-complete premier arg : help, reload si admin.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# SkinView
+# skinview (Heneria)
+
+Plugin Paper/Spigot **1.21** (Java 21) — gestion future de skins pour serveurs offline/cracked.
+
+## Politique dépôt (OBLIGATOIRE)
+- **AUCUN fichier binaire** dans le repository (images, PDF, archives, JAR, etc.)  
+- Le dépôt doit rester **100% TEXTE** (Java, YAML, MD, Gradle…)  
+- Le build exécute `checkNoBinaries` et **échoue** si un binaire est détecté  
+- Les artefacts (JAR…) sont générés dans `build/` et **ne doivent pas** être commit
+
+## Build
+```bash
+./gradlew clean check   # vérifie l'absence de binaires
+./gradlew build         # génère le JAR
+```
+
+## Installation
+Copier build/libs/skinview-*.jar dans plugins/ puis démarrer Paper/Spigot 1.21.x.
+
+## Commandes
+- `/skinview help` — aide
+- `/skinview reload` — recharge config/messages (perm skinview.admin)
+- Aliases: `/skin`, `/sv`.
+
+## Permissions
+- `skinview.use` (par défaut: true)
+- `skinview.admin` (par défaut: op)
+
+## Configs
+`config.yml` et `messages.yml` générés à la première exécution.
+
+## Roadmap
+Tickets suivants : résolution Mojang (async + cache), application via PlayerProfile, persistance, auto-apply au join, fallback TAB.
+
+## Mises à jour
+À chaque ticket, mettre à jour :
+- `build.gradle.kts` (dépendances/versions)
+- `README.md` (sections concernées)
+- `CHANGELOG.md` (entrée détaillée)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,89 @@
+plugins {
+    java
+}
+
+group = "com.heneria"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+    maven("https://repo.papermc.io/repository/maven-public/")
+}
+
+dependencies {
+    // API Paper 1.21.x (compileOnly pour éviter d'embarquer l'API)
+    compileOnly("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
+    // Option Spigot pur (laisser commenté si non utilisé)
+    // compileOnly("org.spigotmc:spigot-api:1.21.1-R0.1-SNAPSHOT")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+    withSourcesJar()
+}
+
+tasks.processResources {
+    // Injecte la version Gradle dans plugin.yml
+    filesMatching("plugin.yml") {
+        expand("version" to project.version)
+    }
+}
+
+tasks.jar {
+    archiveBaseName.set("skinview")
+}
+
+tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
+    options.release.set(21)
+}
+
+/* ==== Politique ANTI-BINAIRES (bloquant) ==== */
+val forbiddenBinaryExtensions = listOf(
+    "jar","class","war","ear","zip","7z","rar","pdf",
+    "png","jpg","jpeg","gif","webp","ico",
+    "exe","dll","so","dylib","bin","dat",
+    "mp3","wav","mp4","mov","avi","mkv"
+)
+
+tasks.register("checkNoBinaries") {
+    group = "verification"
+    description = "Echoue si des fichiers binaires sont présents dans le repo."
+    doLast {
+        val exts = forbiddenBinaryExtensions.toSet()
+        val tree = fileTree(".") {
+            exclude(".git/**", "build/**", ".gradle/**", ".idea/**", "out/**")
+        }
+        val offenders = mutableListOf<File>()
+        tree.files.forEach { f ->
+            if (!f.isFile) return@forEach
+            val name = f.name.lowercase()
+            val ext = name.substringAfterLast('.', "")
+            if (ext in exts) offenders += f
+            else {
+                // Heuristique binaire (NUL byte dans les 4 Ko initiaux)
+                val bytes = f.readBytes()
+                val limit = kotlin.math.min(bytes.size, 4096)
+                var hasNul = false
+                var i = 0
+                while (i < limit) {
+                    if (bytes[i] == 0.toByte()) { hasNul = true; break }
+                    i++
+                }
+                if (hasNul) offenders += f
+            }
+        }
+        if (offenders.isNotEmpty()) {
+            val msg = buildString {
+                appendLine("Interdit: fichiers binaires détectés dans le repository :")
+                offenders.sortedBy { it.path }.forEach { appendLine(" - ${it.path}") }
+                appendLine("Supprimez-les. Le dépôt doit rester 100% TEXTE.")
+            }
+            throw GradleException(msg)
+        }
+    }
+}
+
+tasks.check { dependsOn("checkNoBinaries") }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "skinview"

--- a/src/main/java/com/heneria/skinview/SkinviewPlugin.java
+++ b/src/main/java/com/heneria/skinview/SkinviewPlugin.java
@@ -1,0 +1,86 @@
+package com.heneria.skinview;
+
+import com.heneria.skinview.commands.SkinCommand;
+import com.heneria.skinview.commands.SkinTabCompleter;
+import com.heneria.skinview.listener.InteractListener;
+import com.heneria.skinview.listener.JoinListener;
+import org.bukkit.Bukkit;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.List;
+import java.util.logging.Level;
+
+public final class SkinviewPlugin extends JavaPlugin {
+
+    private FileConfiguration messages;
+
+    @Override
+    public void onEnable() {
+        final long t0 = System.nanoTime();
+
+        // Configs par défaut
+        saveDefaultConfig();
+        saveResource("messages.yml", false);
+        reloadMessages();
+
+        // Commande principale
+        final PluginCommand cmd = getCommand("skinview");
+        if (cmd == null) {
+            getLogger().severe("Commande /skinview introuvable (plugin.yml non packagé ?). Désactivation.");
+            Bukkit.getPluginManager().disablePlugin(this);
+            return;
+        }
+        cmd.setExecutor(new SkinCommand(this));
+        cmd.setTabCompleter(new SkinTabCompleter());
+
+        // Listeners
+        final PluginManager pm = Bukkit.getPluginManager();
+        pm.registerEvents(new JoinListener(this), this);
+        pm.registerEvents(new InteractListener(this), this);
+
+        final long dtMs = (System.nanoTime() - t0) / 1_000_000;
+        getLogger().info(String.format(
+            "skinview v%s enabled in %d ms (Java %s, API %s)",
+            getDescription().getVersion(), dtMs, System.getProperty("java.version"), getServer().getBukkitVersion()
+        ));
+    }
+
+    @Override
+    public void onDisable() {
+        getLogger().info("skinview disabled.");
+    }
+
+    public FileConfiguration messages() {
+        return this.messages;
+    }
+
+    public void reloadAll() {
+        reloadConfig();
+        reloadMessages();
+        getLogger().info("Configuration & messages rechargés.");
+    }
+
+    private void reloadMessages() {
+        try {
+            File file = new File(getDataFolder(), "messages.yml");
+            this.messages = YamlConfiguration.loadConfiguration(file);
+        } catch (Exception e) {
+            getLogger().log(Level.WARNING, "Chargement messages.yml : " + e.getMessage(), e);
+            this.messages = getConfig(); // fallback minimal
+        }
+    }
+
+    public List<String> helpLines() {
+        List<String> lines = messages().getStringList("help");
+        final String ver = getDescription().getVersion();
+        for (int i = 0; i < lines.size(); i++) {
+            lines.set(i, lines.get(i).replace("%version%", ver));
+        }
+        return lines;
+    }
+}

--- a/src/main/java/com/heneria/skinview/commands/SkinCommand.java
+++ b/src/main/java/com/heneria/skinview/commands/SkinCommand.java
@@ -1,0 +1,53 @@
+package com.heneria.skinview.commands;
+
+import com.heneria.skinview.SkinviewPlugin;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public final class SkinCommand implements CommandExecutor {
+
+    private final SkinviewPlugin plugin;
+
+    public SkinCommand(SkinviewPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    private void sendPrefixed(CommandSender sender, String path, String def) {
+        String prefix = ChatColor.translateAlternateColorCodes('&',
+                plugin.messages().getString("prefix", ""));
+        String raw = plugin.messages().getString(path, def);
+        sender.sendMessage(prefix + ChatColor.translateAlternateColorCodes('&', raw));
+    }
+
+    private void sendHelp(CommandSender sender) {
+        String prefix = ChatColor.translateAlternateColorCodes('&',
+                plugin.messages().getString("prefix", ""));
+        for (String raw : plugin.helpLines()) {
+            sender.sendMessage(prefix + ChatColor.translateAlternateColorCodes('&', raw));
+        }
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+
+        if (args.length == 0 || "help".equalsIgnoreCase(args[0])) {
+            sendHelp(sender);
+            return true; // jamais false (évite l'"usage"/écho)
+        }
+
+        if ("reload".equalsIgnoreCase(args[0])) {
+            if (!sender.hasPermission("skinview.admin")) {
+                sendPrefixed(sender, "no-permission", "&cNo permission.");
+                return true;
+            }
+            plugin.reloadAll();
+            sendPrefixed(sender, "reloaded", "&aReloaded.");
+            return true;
+        }
+
+        sendPrefixed(sender, "unknown-subcommand", "&cUnknown subcommand.");
+        return true;
+    }
+}

--- a/src/main/java/com/heneria/skinview/commands/SkinTabCompleter.java
+++ b/src/main/java/com/heneria/skinview/commands/SkinTabCompleter.java
@@ -1,0 +1,23 @@
+package com.heneria.skinview.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class SkinTabCompleter implements TabCompleter {
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> out = new ArrayList<>();
+        if (args.length == 1) {
+            out.add("help");
+            if (sender.hasPermission("skinview.admin")) {
+                out.add("reload");
+            }
+        }
+        return out;
+    }
+}

--- a/src/main/java/com/heneria/skinview/listener/InteractListener.java
+++ b/src/main/java/com/heneria/skinview/listener/InteractListener.java
@@ -1,0 +1,20 @@
+package com.heneria.skinview.listener;
+
+import com.heneria.skinview.SkinviewPlugin;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+public final class InteractListener implements Listener {
+
+    private final SkinviewPlugin plugin;
+
+    public InteractListener(SkinviewPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent e) {
+        // Réservé pour interactions futures (aucune logique en Ticket 1)
+    }
+}

--- a/src/main/java/com/heneria/skinview/listener/JoinListener.java
+++ b/src/main/java/com/heneria/skinview/listener/JoinListener.java
@@ -1,0 +1,21 @@
+package com.heneria.skinview.listener;
+
+import com.heneria.skinview.SkinviewPlugin;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public final class JoinListener implements Listener {
+
+    private final SkinviewPlugin plugin;
+
+    public JoinListener(SkinviewPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent e) {
+        // Ticket 1 : squelette (l’apply skin sera livré dans les tickets suivants)
+        plugin.getLogger().fine("Join: " + e.getPlayer().getName());
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,18 @@
+# skinview — configuration par défaut
+# Rappel: le dépôt doit rester 100% TEXTE (pas de binaires).
+
+apply:
+  update-on-join: true        # sera utilisé aux tickets suivants
+  refresh-tablist: true
+
+cache:
+  ttl-seconds: 3600
+  max-entries: 500
+
+lookups:
+  allow-premium-name: true
+  allow-textures-url: true
+  allow-unsigned: true
+
+logging:
+  level: INFO

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,0 +1,10 @@
+prefix: "&6[skinview]&r "
+
+help:
+  - "&6=== &eSkinView &7(v%version%) &6==="
+  - "&e/skinview help &7: Affiche cette aide"
+  - "&e/skinview reload &7: Recharge la configuration & messages &8(perm: skinview.admin)"
+
+reloaded: "&aConfiguration rechargée."
+no-permission: "&cVous n'avez pas la permission."
+unknown-subcommand: "&cSous-commande inconnue. &7Essayez &e/skinview help&7."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,21 @@
+name: skinview
+main: com.heneria.skinview.SkinviewPlugin
+version: ${version}
+api-version: "1.21"
+author: Heneria
+website: https://heneria.example
+
+commands:
+  skinview:
+    description: Commande principale du plugin skinview
+    usage: "/skinview help"
+    aliases: [skin, sv]
+    permission: skinview.use
+
+permissions:
+  skinview.use:
+    default: true
+    description: Utiliser /skinview (help)
+  skinview.admin:
+    default: op
+    description: Admin (reload + futures opérations sensibles)


### PR DESCRIPTION
## Summary
- scaffold Paper/Spigot skinview plugin for Java 21
- implement /skinview command with help and reload, tab completion, and listeners
- enforce text-only repository via .gitignore, .gitattributes, and checkNoBinaries Gradle task

## Testing
- `gradle clean check` *(fails: Could not resolve io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT (403 Forbidden))*
- `gradle build` *(fails: Could not resolve io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_689ce4460de083248b8aa3eab81662da