### PR TITLE
Ban Gradle wrapper and update build/CI docs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,25 @@
+name: CI (Gradle sans wrapper)
+
+on:
+  push: { branches: [ "**" ] }
+  pull_request: { branches: [ "**" ] }
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      # Installe et utilise Gradle côté runner (aucun wrapper requis dans le repo)
+      - uses: gradle/gradle-build-action@v3
+        with:
+          gradle-version: 8.10.2
+          arguments: clean check --no-daemon
+      - if: ${{ github.event_name == 'pull_request' }}
+        uses: gradle/gradle-build-action@v3
+        with:
+          gradle-version: 8.10.2
+          arguments: build --no-daemon

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,23 @@
-# Gradle / IDE
+# Build & caches
+.build/
 .gradle/
 build/
 out/
+target/
+
+# IDE
 .idea/
 *.iml
+.classpath
+.project
+.settings/
 
-# Binaires & artefacts (interdits au repo)
+# Wrapper Gradle — autorisé en local mais INTERDIT au repo
+gradle/
+gradlew
+gradlew.bat
+
+# Binaires & médias (interdits au repo)
 *.jar
 *.class
 *.war
@@ -20,6 +32,8 @@ out/
 *.gif
 *.webp
 *.ico
+*.bmp
+*.svg
 *.exe
 *.dll
 *.so
@@ -28,10 +42,12 @@ out/
 *.dat
 *.mp3
 *.wav
+*.flac
 *.mp4
 *.mov
 *.avi
 *.mkv
+*.webm
 
 # OS
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.1.4
+- Policy: Gradle conservé mais **Codex ne génère ni ne commit le wrapper**.
+- CI: Gradle 8.10.2 installé côté runner (pas de wrapper requis).
+- Anti-binaires: check strict sans whitelist (échoue si wrapper ou autre binaire poussé).
+- .gitignore: ignore `gradle/`, `gradlew*`.
+
+## 0.1.3
+- Gradle sans wrapper + ban total des binaires (CI + check local)
+
 ## 0.1.0
 - Initialisation du projet skinview (Heneria)
 - Gradle Kotlin DSL (Java 21), Paper API 1.21.x

--- a/README.md
+++ b/README.md
@@ -3,16 +3,28 @@
 Plugin Paper/Spigot **1.21** (Java 21) — gestion future de skins pour serveurs offline/cracked.
 
 ## Politique dépôt (OBLIGATOIRE)
-- **AUCUN fichier binaire** dans le repository (images, PDF, archives, JAR, etc.)  
-- Le dépôt doit rester **100% TEXTE** (Java, YAML, MD, Gradle…)  
-- Le build exécute `checkNoBinaries` et **échoue** si un binaire est détecté  
+- **AUCUN fichier binaire** dans le repository (images, PDF, archives, JAR, etc.)
+- Le dépôt doit rester **100% TEXTE** (Java, YAML, MD, Gradle…)
+- Le build exécute `checkNoBinaries` et **échoue** si un binaire est détecté
 - Les artefacts (JAR…) sont générés dans `build/` et **ne doivent pas** être commit
+- **Pas de wrapper Gradle** dans Git (`gradle/`, `gradlew*`). Si un wrapper est nécessaire sur ta machine, génère-le localement et ne le pousse pas.
+- La CI installe Gradle côté runner.
 
-## Build
+## Build (Gradle **sans wrapper** par défaut)
+Prérequis: **Java 21** et **Gradle 8.10+** installés localement.
 ```bash
-./gradlew clean check   # vérifie l'absence de binaires
-./gradlew build         # génère le JAR
+gradle clean check
+gradle build
 ```
+
+### Option: wrapper local (non versionné)
+Si tu veux un wrapper sur ta machine, tu peux le générer puis **ne pas** le committer:
+```bash
+gradle wrapper --gradle-version 8.10.2
+./gradlew clean check
+./gradlew build
+```
+Important : ne pousse aucun des fichiers du wrapper (`gradle/`, `gradlew`, `gradlew.bat`, `gradle-wrapper.jar`). `.gitignore` les ignore et `checkNoBinaries` échouera si un binaire arrive quand même.
 
 ## Installation
 Copier build/libs/skinview-*.jar dans plugins/ puis démarrer Paper/Spigot 1.21.x.
@@ -31,7 +43,6 @@ Copier build/libs/skinview-*.jar dans plugins/ puis démarrer Paper/Spigot 1.21.
 
 ## Roadmap
 Tickets suivants : résolution Mojang (async + cache), application via PlayerProfile, persistance, auto-apply au join, fallback TAB.
-
 ## Mises à jour
 À chaque ticket, mettre à jour :
 - `build.gradle.kts` (dépendances/versions)


### PR DESCRIPTION
## Summary
- Replace build script to enforce no Gradle wrapper and strengthen binary ban
- Ignore Gradle wrapper files and other binaries
- Document system Gradle usage and optional local wrapper
- Record policy in changelog and add CI workflow installing Gradle

## Testing
- `gradle clean check`


------
https://chatgpt.com/codex/tasks/task_e_689d9fa8ec148324bdbd466b36a39675