### PR TITLE
feat: auto-apply premium skins on join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.3.1
+- Spigot 1.21: auto-apply du skin des comptes premium au join (serveur offline)
+- Impl: Listener `SkinAutoApplyJoinListener` (async resolve → main-thread apply via PlayerProfile/PlayerTextures)
+- Aucun NMS, tick-safe. Logs FINE/INFO.
+- build.gradle.kts: dépendance `org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT`
+
+How-to (build & test rapide)
+
+Build (Gradle système, Java 21)
+
+```
+gradle clean check
+gradle build
+```
+
+Déposer build/libs/skinview-0.3.1.jar dans plugins/ (serveur Spigot 1.21 en offline-mode).
+
+Tests manuels
+
+1. démarrer le serveur.
+2. Rejoindre avec un pseudo premium réel (existant sur Mojang).
+3. Vérifier côté autres joueurs que le skin apparaît (log plugin Applied premium skin ...).
+4. Tester toggles : apply.update-on-join=false → aucun changement de skin au join.
+
+Perf/stabilité
+
+- Aucune I/O réseau sur le main thread (résolution via service async existant).
+- Application strictement main-thread (Spigot-safe).
+- Pas d’allocation massive / pas de scheduler serré (promesses complétées puis 2×2 ticks pour refresh).
+
 ## 0.2.1
 - build: `checkNoBinariesTracked` remplace `checkNoBinaries` — scan basé sur `git ls-files` (uniquement fichiers versionnés).
 - doc: README mis à jour (wrapper local OK si non commité).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skinview (Heneria)
 
-Plugin Paper/Spigot **1.21** (Java 21) — gestion future de skins pour serveurs offline/cracked.
+Plugin Spigot **1.21** (Java 21) — gestion future de skins pour serveurs offline/cracked.
 
 ## Politique dépôt
 - Dépôt **100% TEXTE** : la tâche `checkNoBinariesTracked` scanne uniquement les fichiers *versionnés* (via `git ls-files`).
@@ -25,7 +25,24 @@ gradle wrapper --gradle-version 8.10.2
 Important : ne pousse aucun des fichiers du wrapper (`gradle/`, `gradlew`, `gradlew.bat`, `gradle-wrapper.jar`). `.gitignore` les ignore et `checkNoBinariesTracked` échouera si un binaire arrive quand même.
 
 ## Installation
-Copier build/libs/skinview-*.jar dans plugins/ puis démarrer Paper/Spigot 1.21.x.
+Copier build/libs/skinview-*.jar dans plugins/ puis démarrer Spigot 1.21.x.
+
+## Plateforme
+- **Spigot 1.21** (pas Paper). API utilisée : `PlayerProfile` / `PlayerTextures` (aucun NMS).
+
+## Comportement (auto-apply premium au join)
+- Si `apply.update-on-join: true` et que le pseudo du joueur existe chez Mojang,
+  le skin est résolu **async** et appliqué **main-thread** via `PlayerProfile`.
+- Option `apply.refresh-tablist: true` pour un léger hide/show (meilleure propagation client).
+
+## Config (extrait pertinent)
+```yaml
+apply:
+  update-on-join: true
+  refresh-tablist: true
+lookups:
+  allow-premium-name: true
+```
 
 ## Résolution de skins
 Service interne `SkinResolver` : résolution Mojang (pseudo premium) ou URL `textures.minecraft.net`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,16 +3,17 @@ import java.io.ByteArrayOutputStream
 plugins { java }
 
 group = "com.heneria"
-version = "0.2.1" // fix: scan seulement des fichiers git-trackés
+version = "0.3.1" // Spigot 1.21 - auto-apply premium skins on join
 
 repositories {
     mavenCentral()
-    maven("https://repo.papermc.io/repository/maven-public/")
+    maven("https://repo.papermc.io/repository/maven-public/") // ok de laisser, mais non utilisé
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
-    // compileOnly("org.spigotmc:spigot-api:1.21.1-R0.1-SNAPSHOT")
+    // ===== Spigot 1.21 (PAS Paper) =====
+    compileOnly("org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT")
+    // (supprimer toute dépendance paper-api si présente)
 }
 
 java {

--- a/src/main/java/com/heneria/skinview/SkinviewPlugin.java
+++ b/src/main/java/com/heneria/skinview/SkinviewPlugin.java
@@ -42,6 +42,8 @@ public final class SkinviewPlugin extends JavaPlugin {
         final PluginManager pm = Bukkit.getPluginManager();
         pm.registerEvents(new JoinListener(this), this);
         pm.registerEvents(new InteractListener(this), this);
+        // +++ Auto-apply premium skins on join (Spigot)
+        pm.registerEvents(new com.heneria.skinview.listener.SkinAutoApplyJoinListener(this), this);
 
         // Service resolver (async + cache)
         this.resolver = new MojangSkinResolver(this);

--- a/src/main/java/com/heneria/skinview/listener/SkinAutoApplyJoinListener.java
+++ b/src/main/java/com/heneria/skinview/listener/SkinAutoApplyJoinListener.java
@@ -1,0 +1,83 @@
+package com.heneria.skinview.listener;
+
+import com.heneria.skinview.SkinviewPlugin;
+import com.heneria.skinview.service.SkinDescriptor;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.profile.PlayerProfile;
+import org.bukkit.profile.PlayerTextures;
+
+import java.net.URL;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+
+/**
+ * Spigot 1.21 — Auto-apply du skin premium au join (serveur offline).
+ * - Résolution async par pseudo Mojang
+ * - Application main-thread via PlayerProfile/PlayerTextures
+ * - Aucun NMS, tick-safe
+ */
+public final class SkinAutoApplyJoinListener implements Listener {
+
+    private final SkinviewPlugin plugin;
+
+    public SkinAutoApplyJoinListener(SkinviewPlugin plugin) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent e) {
+        if (!plugin.getConfig().getBoolean("apply.update-on-join", true)) return;
+        if (!plugin.getConfig().getBoolean("lookups.allow-premium-name", true)) return;
+
+        final Player player = e.getPlayer();
+        final String name = player.getName();
+
+        // Résolution async (ne JAMAIS bloquer le main thread)
+        CompletableFuture<SkinDescriptor> fut = plugin.resolver().resolveByPremiumName(name);
+        fut.whenComplete((sd, ex) -> {
+            if (ex != null) {
+                plugin.getLogger().log(Level.FINE, "[skinview] No premium skin for " + name + " (" + ex.getMessage() + ")");
+                return; // rien à faire si non-premium ou échec réseau
+            }
+            // Application main-thread
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                try {
+                    Player p = Bukkit.getPlayer(player.getUniqueId());
+                    if (p == null || !p.isOnline()) return;
+
+                    PlayerProfile profile = p.getPlayerProfile();
+                    PlayerTextures textures = profile.getTextures();
+
+                    URL skinUrl = sd.skinUrl().toURL(); // textures.minecraft.net/...
+                    textures.setSkin(skinUrl);
+                    profile.setTextures(textures);
+                    p.setPlayerProfile(profile);
+
+                    // Optionnel : petit refresh léger pour propager aux autres clients (pas de NMS)
+                    if (plugin.getConfig().getBoolean("apply.refresh-tablist", true)) {
+                        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                            for (Player viewer : Bukkit.getOnlinePlayers()) {
+                                if (!viewer.equals(p)) viewer.hidePlayer(plugin, p);
+                            }
+                            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                                for (Player viewer : Bukkit.getOnlinePlayers()) {
+                                    if (!viewer.equals(p)) viewer.showPlayer(plugin, p);
+                                }
+                            }, 2L);
+                        }, 2L);
+                    }
+
+                    plugin.getLogger().fine("[skinview] Applied premium skin to " + name + " (" + sd.model() + ")");
+                } catch (Exception err) {
+                    plugin.getLogger().log(Level.WARNING, "[skinview] apply failed for " + name + ": " + err.getMessage(), err);
+                }
+            });
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- bump to Spigot 1.21 API and plugin version 0.3.1
- auto-apply premium skins asynchronously on player join
- document Spigot platform and behavior in README and changelog

## Testing
- `gradle clean check` *(fails: Could not resolve org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT (403 Forbidden))*
- `gradle build` *(fails: Could not resolve org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_689db6d3535c83248bb703e1935b324d