### PR TITLE
fix: correct JsonUtils regex escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.2
+- Fix: `JsonUtils` — chaînes regex corrigées (échappement des guillemets et backslashes en Java). La compilation CI ne plante plus.
+
 ## 0.4.1
 - Build: option **`-PwithPlib`** pour compiler/inclure les classes ProtocolLib uniquement à la demande.
 - CI: passe sans tenter de résoudre ProtocolLib (aucune dépendance par défaut).

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Tout est async, aucun blocage du tick.
 
 ## Roadmap
 Tickets suivants : application via PlayerProfile, persistance, auto-apply au join, fallback TAB.
+### Notes techniques
+- 0.4.2: correction des chaînes regex dans `JsonUtils` (échappement Java corrigé).
+
 ## Mises à jour
 À chaque ticket, mettre à jour :
 - `build.gradle.kts` (dépendances/versions)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import java.io.ByteArrayOutputStream
 plugins { java }
 
 group = "com.heneria"
-version = "0.4.1" // CI sans ProtocolLib par défaut (build optionnel avec -PwithPlib)
+version = "0.4.2" // fix: JsonUtils (échappement regex corrigé)
 
 repositories {
     mavenCentral()
@@ -20,11 +20,12 @@ java {
     toolchain { languageVersion.set(JavaLanguageVersion.of(21)) }
     withSourcesJar()
 }
-
 tasks.processResources {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     filesMatching("plugin.yml") { expand("version" to project.version) }
 }
 
+tasks.withType<AbstractCopyTask> { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
 tasks.jar { archiveBaseName.set("skinview") }
 
 tasks.withType<JavaCompile> {

--- a/src/main/java/com/heneria/skinview/util/JsonUtils.java
+++ b/src/main/java/com/heneria/skinview/util/JsonUtils.java
@@ -12,34 +12,42 @@ public final class JsonUtils {
 
     /** Cherche "key":"value" (niveau simple). */
     public static Optional<String> findString(String json, String key) {
-        Matcher m = Pattern.compile("\\"" + q(key) + "\\"\\s*:\\s*\\"([^\\"]*)\\"").matcher(json);
+        Pattern p = Pattern.compile("\"" + q(key) + "\"\s*:\s*\"([^\"]*)\"");
+        Matcher m = p.matcher(json);
         return m.find() ? Optional.ofNullable(m.group(1)) : Optional.empty();
     }
 
-    /** Dans la réponse sessionserver: properties[..].value (Base64). */
+    /** properties[..].value (Base64) dans la réponse sessionserver. */
     public static Optional<String> findFirstValuePropertyBase64(String json) {
-        Matcher arr = Pattern.compile("\\"properties\\"\\s*:\\s*\\[(.*?)\\]", Pattern.DOTALL).matcher(json);
+        Matcher arr = Pattern.compile("\"properties\"\s*:\s*\\[(.*?)\\]", Pattern.DOTALL)
+                .matcher(json);
         if (!arr.find()) return Optional.empty();
-        Matcher mv = Pattern.compile("\\"value\\"\\s*:\\s*\\"([^\\"]+)\\"").matcher(arr.group(1));
+        Matcher mv = Pattern.compile("\"value\"\s*:\s*\"([^\"]+)\"")
+                .matcher(arr.group(1));
         return mv.find() ? Optional.ofNullable(mv.group(1)) : Optional.empty();
     }
 
-    /** Dans la réponse sessionserver: properties[..].signature. */
+    /** properties[..].signature (signature Mojang de la propriété textures). */
     public static Optional<String> findFirstValuePropertySignature(String json) {
-        Matcher arr = Pattern.compile("\\"properties\\"\\s*:\\s*\\[(.*?)\\]", Pattern.DOTALL).matcher(json);
+        Matcher arr = Pattern.compile("\"properties\"\s*:\s*\\[(.*?)\\]", Pattern.DOTALL)
+                .matcher(json);
         if (!arr.find()) return Optional.empty();
-        Matcher ms = Pattern.compile("\\"signature\\"\\s*:\\s*\\"([^\\"]+)\\"").matcher(arr.group(1));
+        Matcher ms = Pattern.compile("\"signature\"\s*:\s*\"([^\"]+)\"")
+                .matcher(arr.group(1));
         return ms.find() ? Optional.ofNullable(ms.group(1)) : Optional.empty();
     }
 
-    /** `textures` → SKIN.url */
+    /** Dans le JSON décodé de `value` (textures) → SKIN.url */
     public static Optional<String> findSkinUrl(String texturesJson) {
-        return findString(texturesJson, "url");
+        Matcher m = Pattern.compile("\"SKIN\"\s*:\s*\\{[^}]*\"url\"\s*:\s*\"([^\"]+)\"", Pattern.DOTALL)
+                .matcher(texturesJson);
+        return m.find() ? Optional.ofNullable(m.group(1)) : Optional.empty();
     }
 
-    /** `textures` → SKIN.metadata.model (ex: "slim") */
+    /** Dans le JSON décodé de `value` (textures) → SKIN.metadata.model (ex: "slim"). */
     public static Optional<String> findSkinModel(String texturesJson) {
-        return findString(texturesJson, "model");
+        Matcher m = Pattern.compile("\"SKIN\"\s*:\s*\\{[^}]*\"metadata\"\s*:\s*\\{[^}]*\"model\"\s*:\s*\"([^\"]+)\"", Pattern.DOTALL)
+                .matcher(texturesJson);
+        return m.find() ? Optional.ofNullable(m.group(1)) : Optional.empty();
     }
 }
-


### PR DESCRIPTION
## Summary
- fix JSON regex quoting in JsonUtils
- bump version to 0.4.2 and allow duplicate resources in build
- document regex fix in README and changelog

## Testing
- `gradle check`
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_689de52d8b0483249c6bfc64cf564cf3