### PR TITLE
feat: add ProtocolLib skin applier with signed textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.0
+- modèle: `SkinDescriptor` étendu (`textures.value` + `signature`)
+- resolver: extraction value/signature du sessionserver Mojang
+- feature: `SkinApplierProtocolLib` réécrit le `GameProfile` (ProtocolLib, paquets PLAYER_INFO)
+- plugin: sélection d'applier via réflexion (ProtocolLib → Paper → no-op)
+
 ## 0.4.2
 - Fix: `JsonUtils` — chaînes regex corrigées (échappement des guillemets et backslashes en Java). La compilation CI ne plante plus.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Copier build/libs/skinview-*.jar dans plugins/ puis démarrer Spigot 1.21.x.
 
 ### Serveur
 Spigot 1.21 + offline-mode : pour l’apply live des skins, installe ProtocolLib côté serveur.
+L’applier ProtocolLib réécrit le `GameProfile` (textures `value` + `signature`) envoyé aux autres joueurs.
 Le JAR buildé avec `-PwithPlib=true` active automatiquement le chemin ProtocolLib (softdepend), sinon fallback.
 
 ## Plateforme

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import java.io.ByteArrayOutputStream
 plugins { java }
 
 group = "com.heneria"
-version = "0.4.2" // fix: JsonUtils (échappement regex corrigé)
+version = "0.5.0" // feat: ProtocolLib signed skins applier
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/heneria/skinview/SkinviewPlugin.java
+++ b/src/main/java/com/heneria/skinview/SkinviewPlugin.java
@@ -7,7 +7,7 @@ import com.heneria.skinview.listener.JoinListener;
 import com.heneria.skinview.service.SkinApplier;
 import com.heneria.skinview.service.SkinResolver;
 import com.heneria.skinview.service.impl.MojangSkinResolver;
-import com.heneria.skinview.service.impl.SkinApplierReflection;
+import com.heneria.skinview.service.impl.PaperSkinApplier;
 import org.bukkit.Bukkit;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -23,7 +23,7 @@ public final class SkinviewPlugin extends JavaPlugin {
 
     private FileConfiguration messages;
     private SkinResolver resolver;
-    private SkinApplier applier;
+    private SkinApplier applier; // <— conserver une référence pour shutdown
 
     @Override
     public void onEnable() {
@@ -51,19 +51,8 @@ public final class SkinviewPlugin extends JavaPlugin {
         // Service resolver (async + cache)
         this.resolver = new MojangSkinResolver(this);
 
-        boolean plibEnabled = getConfig().getBoolean("apply.protocollib-enable", true)
-                && Bukkit.getPluginManager().getPlugin("ProtocolLib") != null;
-        if (plibEnabled) {
-            try {
-                Class<?> clazz = Class.forName("com.heneria.skinview.service.impl.SkinApplierProtocolLib");
-                this.applier = (SkinApplier) clazz.getConstructor(SkinviewPlugin.class).newInstance(this);
-            } catch (Exception e) {
-                getLogger().info("ProtocolLib applier non présent (build sans PLib ?)");
-                this.applier = new SkinApplierReflection(this);
-            }
-        } else {
-            this.applier = new SkinApplierReflection(this);
-        }
+        // Sélection d’applier (ProtocolLib si dispo + classe présente dans le JAR)
+        this.applier = chooseApplier();
 
         final long dtMs = (System.nanoTime() - t0) / 1_000_000;
         getLogger().info(String.format(
@@ -74,15 +63,45 @@ public final class SkinviewPlugin extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        if (resolver != null) { resolver.shutdown(); resolver = null; }
+        // Arrêt applier PLib si présent
         if (applier != null) {
-            applier.shutdown();
+            try {
+                if (applier.getClass().getName().endsWith("SkinApplierProtocolLib")) {
+                    applier.getClass().getMethod("shutdown").invoke(applier);
+                }
+            } catch (Exception ignored) {}
             applier = null;
         }
-        if (resolver != null) {
-            resolver.shutdown();
-            resolver = null;
-        }
         getLogger().info("skinview disabled.");
+    }
+
+    private SkinApplier chooseApplier() {
+        // 1) ProtocolLib?
+        boolean enablePlib = getConfig().getBoolean("apply.protocollib-enable", true);
+        if (enablePlib && getServer().getPluginManager().getPlugin("ProtocolLib") != null) {
+            try {
+                Class<?> c = Class.forName("com.heneria.skinview.service.impl.SkinApplierProtocolLib");
+                return (SkinApplier) c.getConstructor(SkinviewPlugin.class).newInstance(this);
+            } catch (ClassNotFoundException ignored) {
+                getLogger().info("[skinview] Classe PLib absente du JAR (build sans -PwithPlib). Fallback.");
+            } catch (Exception e) {
+                getLogger().warning("[skinview] Echec init ProtocolLib applier: " + e.getMessage());
+            }
+        }
+        // 2) Paper via réflexion (si dispo)
+        try {
+            // quick test: Player#setPlayerProfile existe ?
+            org.bukkit.entity.Player.class.getMethod("setPlayerProfile", org.bukkit.profile.PlayerProfile.class);
+            getLogger().info("[skinview] Applier Paper (reflection).");
+            return new PaperSkinApplier(this);
+        } catch (NoSuchMethodException ignored) {
+            getLogger().info("[skinview] Spigot sans ProtocolLib: apply live non disponible (fallback).");
+            return new SkinApplier() {
+                @Override public void apply(org.bukkit.entity.Player p, com.heneria.skinview.service.SkinDescriptor d) { /* no-op */ }
+                @Override public void clear(org.bukkit.entity.Player p) { /* no-op */ }
+            };
+        }
     }
 
     public FileConfiguration messages() { return this.messages; }

--- a/src/main/java/com/heneria/skinview/service/SkinDescriptor.java
+++ b/src/main/java/com/heneria/skinview/service/SkinDescriptor.java
@@ -3,30 +3,28 @@ package com.heneria.skinview.service;
 import java.net.URI;
 import java.util.Objects;
 
-/** Descripteur complet d’un skin : URL textures + modèle + propriété signée. */
+/** Descripteur complet d’un skin Mojang. */
 public final class SkinDescriptor {
     private final URI skinUrl;
     private final SkinModel model;
-    private final String texturesValueB64;
-    private final String texturesSignature;
-
-    public SkinDescriptor(URI skinUrl, SkinModel model) {
-        this(skinUrl, model, null, null);
-    }
+    private final String texturesValueB64;   // propriété "textures".value (Base64)
+    private final String texturesSignature;  // propriété "textures".signature (Mojang)
 
     public SkinDescriptor(URI skinUrl, SkinModel model, String texturesValueB64, String texturesSignature) {
         this.skinUrl = Objects.requireNonNull(skinUrl, "skinUrl");
         this.model = Objects.requireNonNull(model, "model");
-        this.texturesValueB64 = texturesValueB64;
-        this.texturesSignature = texturesSignature;
+        this.texturesValueB64 = texturesValueB64;     // peut être null s’il vient d’une URL directe
+        this.texturesSignature = texturesSignature;   // idem
     }
 
     public URI skinUrl() { return skinUrl; }
     public SkinModel model() { return model; }
-    public String texturesValueBase64() { return texturesValueB64; }
+    public String texturesValueB64() { return texturesValueB64; }
     public String texturesSignature() { return texturesSignature; }
+    public boolean hasSignedTextures() { return texturesValueB64 != null && texturesSignature != null; }
 
     @Override public String toString() {
-        return "SkinDescriptor{url=" + skinUrl + ", model=" + model + '}';
+        return "SkinDescriptor{url=" + skinUrl + ", model=" + model +
+                ", signed=" + hasSignedTextures() + '}';
     }
 }

--- a/src/main/java/com/heneria/skinview/service/impl/PaperSkinApplier.java
+++ b/src/main/java/com/heneria/skinview/service/impl/PaperSkinApplier.java
@@ -14,17 +14,17 @@ import java.util.Objects;
 import java.util.logging.Level;
 
 /** Applier basé sur l'API Paper (réflexion). */
-public final class SkinApplierReflection implements SkinApplier {
+public final class PaperSkinApplier implements SkinApplier {
 
     private final SkinviewPlugin plugin;
     private final Method setPlayerProfile;
 
-    public SkinApplierReflection(SkinviewPlugin plugin) {
+    public PaperSkinApplier(SkinviewPlugin plugin) {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
         Method m;
         try {
             m = Player.class.getMethod("setPlayerProfile", PlayerProfile.class);
-            plugin.getLogger().info("Using reflection applier (Paper path)");
+            plugin.getLogger().info("[skinview] Applier Paper (reflection)");
         } catch (NoSuchMethodException e) {
             m = null;
             plugin.getLogger().info("Spigot runtime sans ProtocolLib — apply live non disponible");
@@ -49,10 +49,10 @@ public final class SkinApplierReflection implements SkinApplier {
                     Bukkit.getScheduler().runTaskLater(plugin, () -> {
                         for (Player viewer : Bukkit.getOnlinePlayers()) if (!viewer.equals(player)) viewer.showPlayer(plugin, player);
                     }, 2L);
-                }, 2L);
-            }
+            }, 2L);
+        }
 
-            plugin.getLogger().fine("[skinview] Applied premium skin (Paper path)");
+        plugin.getLogger().fine("[skinview] Applied premium skin (Paper path)");
         } catch (Exception e) {
             plugin.getLogger().log(Level.WARNING, "[skinview] apply failed: " + e.getMessage(), e);
         }

--- a/src/with-plib/java/com/heneria/skinview/service/impl/SkinApplierProtocolLib.java
+++ b/src/with-plib/java/com/heneria/skinview/service/impl/SkinApplierProtocolLib.java
@@ -1,114 +1,127 @@
 package com.heneria.skinview.service.impl;
 
-import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.ProtocolLibrary;
-import com.comphenix.protocol.ProtocolManager;
-import com.comphenix.protocol.events.ListenerPriority;
-import com.comphenix.protocol.events.PacketAdapter;
-import com.comphenix.protocol.events.PacketEvent;
-import com.comphenix.protocol.wrappers.EnumWrappers;
-import com.comphenix.protocol.wrappers.PlayerInfoData;
-import com.comphenix.protocol.wrappers.WrappedGameProfile;
-import com.comphenix.protocol.wrappers.WrappedSignedProperty;
 import com.heneria.skinview.SkinviewPlugin;
 import com.heneria.skinview.service.SkinApplier;
 import com.heneria.skinview.service.SkinDescriptor;
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.*;
+import com.comphenix.protocol.wrappers.*;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-/** Applier via ProtocolLib: réécriture PLAYER_INFO_UPDATE. */
-public final class SkinApplierProtocolLib implements SkinApplier {
-
+public final class SkinApplierProtocolLib implements SkinApplier, ListenerPriorityAccessor {
     private final SkinviewPlugin plugin;
-    private final ProtocolManager pm;
-    private final ConcurrentHashMap<UUID, SkinProperty> pending = new ConcurrentHashMap<>();
-    private PacketAdapter listener;
+    private final ProtocolManager manager;
+    private final Map<UUID, SignedTex> pending = new ConcurrentHashMap<>();
+    private PacketAdapter adapter;
 
     public SkinApplierProtocolLib(SkinviewPlugin plugin) {
-        this.plugin = Objects.requireNonNull(plugin, "plugin");
-        this.pm = ProtocolLibrary.getProtocolManager();
-        this.listener = new PacketAdapter(plugin, ListenerPriority.NORMAL, PacketType.Play.Server.PLAYER_INFO_UPDATE) {
-            @Override
-            public void onPacketSending(PacketEvent event) {
-                Set<EnumWrappers.PlayerInfoAction> actions = event.getPacket().getPlayerInfoActions().read(0);
-                if (!actions.contains(EnumWrappers.PlayerInfoAction.ADD_PLAYER)) return;
+        this.plugin = plugin;
+        this.manager = ProtocolLibrary.getProtocolManager();
+        register();
+        plugin.getLogger().info("[skinview] ProtocolLib applier actif.");
+    }
 
-                List<PlayerInfoData> list = event.getPacket().getPlayerInfoDataLists().read(0);
-                List<PlayerInfoData> out = new ArrayList<>(list.size());
+    private void register() {
+        adapter = new PacketAdapter(plugin, getPriority(),
+                PacketType.Play.Server.PLAYER_INFO,
+                PacketType.Play.Server.PLAYER_INFO_UPDATE) {
+            @Override public void onPacketSending(PacketEvent event) {
+                PacketContainer packet = event.getPacket();
+
+                // Actions (ADD_PLAYER requis)
+                Set<EnumWrappers.PlayerInfoAction> actions = EnumSet.noneOf(EnumWrappers.PlayerInfoAction.class);
+                try {
+                    actions = packet.getPlayerInfoActions().read(0);
+                } catch (Exception ignored) { /* older variants may not expose actions here */ }
+
+                boolean addPlayer = actions.isEmpty() || actions.contains(EnumWrappers.PlayerInfoAction.ADD_PLAYER);
+
+                List<PlayerInfoData> list = packet.getPlayerInfoDataLists().read(0);
                 boolean modified = false;
+                List<PlayerInfoData> out = new ArrayList<>(list.size());
 
                 for (PlayerInfoData pid : list) {
-                    UUID id = pid.getProfile().getUUID();
-                    SkinProperty prop = pending.remove(id);
-                    if (prop != null) {
-                        WrappedGameProfile gp = new WrappedGameProfile(id, pid.getProfile().getName());
-                        gp.getProperties().put("textures", new WrappedSignedProperty("textures", prop.value(), prop.signature()));
-                        PlayerInfoData npid = new PlayerInfoData(gp, pid.getLatency(), pid.getGameMode(), pid.getDisplayName(), pid.getListed());
+                    WrappedGameProfile old = pid.getProfile();
+                    UUID uuid = old.getUUID();
+                    SignedTex st = pending.get(uuid);
+
+                    if (st != null && addPlayer) {
+                        WrappedGameProfile gp = new WrappedGameProfile(uuid, old.getName());
+                        gp.getProperties().clear();
+                        gp.getProperties().put("textures", new WrappedSignedProperty("textures", st.value(), st.signature()));
+
+                        PlayerInfoData npid = new PlayerInfoData(
+                                gp,
+                                pid.getLatency(),
+                                pid.getGameMode(),
+                                pid.getDisplayName()
+                        );
                         out.add(npid);
                         modified = true;
+                        // retire la demande après premier envoi
+                        pending.remove(uuid);
                     } else {
                         out.add(pid);
                     }
                 }
 
                 if (modified) {
-                    event.getPacket().getPlayerInfoDataLists().write(0, out);
+                    packet.getPlayerInfoDataLists().write(0, out);
                 }
             }
         };
-        pm.addPacketListener(listener);
-        plugin.getLogger().info("Using ProtocolLib applier");
+        manager.addPacketListener(adapter);
     }
 
-    @Override
-    public void apply(Player player, SkinDescriptor sd) {
-        String value = sd.texturesValueBase64();
-        String sig = sd.texturesSignature();
-        if (value == null || sig == null) {
-            // Tentative de re-résolution nominative
-            plugin.resolver().resolveByPremiumName(player.getName()).whenComplete((nsd, ex) -> {
-                if (nsd != null && ex == null) {
-                    Bukkit.getScheduler().runTask(plugin, () -> apply(player, nsd));
+    @Override public void apply(Player player, SkinDescriptor descriptor) throws Exception {
+        if (!descriptor.hasSignedTextures())
+            throw new IllegalArgumentException("Signed textures required (value+signature)");
+        pending.put(player.getUniqueId(), new SignedTex(descriptor.texturesValueB64(), descriptor.texturesSignature()));
+
+        // Déclenchement des paquets ADD_PLAYER pour les autres
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            for (Player viewer : Bukkit.getOnlinePlayers()) {
+                if (!viewer.equals(player)) viewer.hidePlayer(plugin, player);
+            }
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                for (Player viewer : Bukkit.getOnlinePlayers()) {
+                    if (!viewer.equals(player)) viewer.showPlayer(plugin, player);
                 }
-            });
-            return;
-        }
-
-        pending.put(player.getUniqueId(), new SkinProperty(value, sig));
-
-        for (Player viewer : Bukkit.getOnlinePlayers()) if (!viewer.equals(player)) viewer.hidePlayer(plugin, player);
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
-            for (Player viewer : Bukkit.getOnlinePlayers()) if (!viewer.equals(player)) viewer.showPlayer(plugin, player);
-        }, 2L);
-
-        plugin.getLogger().fine("[skinview] Applied premium skin (ProtocolLib path)");
+            }, 2L);
+        });
     }
 
-    @Override
-    public void clear(Player player) {
+    @Override public void clear(Player player) {
         pending.remove(player.getUniqueId());
-        for (Player viewer : Bukkit.getOnlinePlayers()) if (!viewer.equals(player)) viewer.hidePlayer(plugin, player);
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
-            for (Player viewer : Bukkit.getOnlinePlayers()) if (!viewer.equals(player)) viewer.showPlayer(plugin, player);
-        }, 2L);
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            for (Player viewer : Bukkit.getOnlinePlayers())
+                if (!viewer.equals(player)) viewer.hidePlayer(plugin, player);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                for (Player viewer : Bukkit.getOnlinePlayers())
+                    if (!viewer.equals(player)) viewer.showPlayer(plugin, player);
+            }, 2L);
+        });
     }
 
-    @Override
     public void shutdown() {
-        if (listener != null) {
-            pm.removePacketListener(listener);
-            listener = null;
+        if (adapter != null) {
+            manager.removePacketListener(adapter);
+            adapter = null;
         }
         pending.clear();
     }
 
-    private record SkinProperty(String value, String signature) {}
-}
+    // Priorité haute mais non bloquante
+    @Override public ListenerPriority getPriority() {
+        return ListenerPriority.HIGH;
+    }
 
+    private record SignedTex(String value, String signature) {}
+    private interface ListenerPriorityAccessor { ListenerPriority getPriority(); }
+}


### PR DESCRIPTION
## Summary
- extend SkinDescriptor with textures value and signature
- extract signed texture data from session server and expose in resolver
- introduce optional ProtocolLib skin applier and reflection-based wiring

## Testing
- `gradle clean check`
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_689deb2a9eec832490cf878878623110