### PR TITLE
feat: persist premium skins and cache commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - resolver: extraction value/signature du sessionserver Mojang
 - feature: `SkinApplierProtocolLib` réécrit le `GameProfile` (ProtocolLib, paquets PLAYER_INFO)
 - plugin: sélection d'applier via réflexion (ProtocolLib → Paper → no-op)
+- persistance: nouveau `YamlSkinStore` (plugins/skinview/data/skins.yml) avec TTL configurable
+- service: `SkinService` sauvegarde après apply et permet `applyFromStore(...)`
+- listener: auto-apply prioritaire depuis le store puis fallback Mojang
+- commandes: `/skinview cache get|clear` pour interagir avec le store
+- config: section `storage.*` (type, fichier, ttl-seconds)
 
 ## 0.4.2
 - Fix: `JsonUtils` — chaînes regex corrigées (échappement des guillemets et backslashes en Java). La compilation CI ne plante plus.

--- a/src/main/java/com/heneria/skinview/commands/SkinCommand.java
+++ b/src/main/java/com/heneria/skinview/commands/SkinCommand.java
@@ -1,12 +1,11 @@
 package com.heneria.skinview.commands;
 
 import com.heneria.skinview.SkinviewPlugin;
-import com.heneria.skinview.service.SkinDescriptor;
+import com.heneria.skinview.service.SkinService;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.*;
-
-import java.util.concurrent.CompletableFuture;
+import org.bukkit.entity.Player;
 
 public final class SkinCommand implements CommandExecutor {
 
@@ -23,6 +22,18 @@ public final class SkinCommand implements CommandExecutor {
     private void sendHelp(CommandSender sender) {
         String prefix = ChatColor.translateAlternateColorCodes('&', plugin.messages().getString("prefix", ""));
         for (String raw : plugin.helpLines()) sender.sendMessage(prefix + ChatColor.translateAlternateColorCodes('&', raw));
+    }
+
+    private Player resolveTarget(CommandSender sender, String[] args, int index) {
+        if (args.length <= index) {
+            if (sender instanceof Player p) return p;
+            return null;
+        }
+        return Bukkit.getPlayerExact(args[index]);
+    }
+
+    private boolean canTargetOthers(CommandSender sender) {
+        return sender.hasPermission("skinview.admin");
     }
 
     @Override
@@ -42,29 +53,79 @@ public final class SkinCommand implements CommandExecutor {
         if ("resolve".equalsIgnoreCase(args[0])) {
             if (!sender.hasPermission("skinview.admin")) { sendPrefixed(sender, "no-permission", "&cNo permission."); return true; }
             if (args.length < 3) { sendPrefixed(sender, "resolve-usage", "&eUsage: /skinview resolve <name|url> <value>"); return true; }
-
             String type = args[1].toLowerCase();
             String value = args[2];
             sendPrefixed(sender, "resolve-started", "&7Résolution en cours...");
-
-            CompletableFuture<SkinDescriptor> fut;
-            if ("name".equals(type)) fut = plugin.resolver().resolveByPremiumName(value);
-            else if ("url".equals(type)) fut = plugin.resolver().resolveByTexturesUrl(value);
-            else { sendPrefixed(sender, "resolve-usage", "&eUsage: /skinview resolve <name|url> <value>"); return true; }
-
+            var fut = "name".equals(type)
+                    ? plugin.resolver().resolveByPremiumName(value)
+                    : "url".equals(type) ? plugin.resolver().resolveByTexturesUrl(value)
+                    : null;
+            if (fut == null) { sendPrefixed(sender, "resolve-usage", "&eUsage: /skinview resolve <name|url> <value>"); return true; }
             fut.whenComplete((sd, ex) -> Bukkit.getScheduler().runTask(plugin, () -> {
-                if (ex != null) {
-                    sendPrefixed(sender, "resolve-fail", "&cÉchec de résolution: " + ex.getMessage());
-                } else {
-                    sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
-                            plugin.messages().getString("prefix", "") +
-                                    "&aOK&7 → &f" + sd.skinUrl() + " &7(" + sd.model() + ")"));
-                }
+                if (ex != null) sendPrefixed(sender, "resolve-fail", "&cÉchec: %error%".replace("%error%", ex.getMessage()));
+                else sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                        plugin.messages().getString("prefix", "") + "&aOK&7 (voir console pour détails éventuels)"));
             }));
             return true;
+        }
+
+        if ("use".equalsIgnoreCase(args[0]) || "url".equalsIgnoreCase(args[0])) {
+            boolean byName = "use".equalsIgnoreCase(args[0]);
+            if (args.length < 2) { sendPrefixed(sender, "invalid-arg", "&cArguments invalides."); return true; }
+            Player target = resolveTarget(sender, args, 2);
+            if (target == null) {
+                if (args.length >= 3 && !(sender instanceof Player)) {
+                    sendPrefixed(sender, "player-not-found", "&cJoueur introuvable: %player%".replace("%player%", args[2]));
+                    return true;
+                }
+                if (!(sender instanceof Player)) { sendPrefixed(sender, "invalid-arg", "&cSpécifiez un joueur."); return true; }
+            }
+            if (target != null && !((sender instanceof Player p && p.equals(target)) || canTargetOthers(sender))) {
+                sendPrefixed(sender, "no-permission", "&cNo permission."); return true;
+            }
+            SkinService svc = plugin.skinService();
+            if (byName) svc.applyByPremiumName(sender, target != null ? target : (Player) sender, args[1]);
+            else svc.applyByTexturesUrl(sender, target != null ? target : (Player) sender, args[1]);
+            return true;
+        }
+
+        if ("clear".equalsIgnoreCase(args[0])) {
+            Player target = resolveTarget(sender, args, 1);
+            if (target == null) {
+                if (args.length >= 2) sendPrefixed(sender, "player-not-found", "&cJoueur introuvable: %player%".replace("%player%", args[1]));
+                else if (!(sender instanceof Player)) sendPrefixed(sender, "invalid-arg", "&cSpécifiez un joueur.");
+                return true;
+            }
+            if (!((sender instanceof Player p && p.equals(target)) || canTargetOthers(sender))) {
+                sendPrefixed(sender, "no-permission", "&cNo permission."); return true;
+            }
+            plugin.skinService().clearCache(sender, target);
+            return true;
+        }
+
+        if ("cache".equalsIgnoreCase(args[0])) {
+            if (!sender.hasPermission("skinview.admin")) { sendPrefixed(sender, "no-permission", "&cNo permission."); return true; }
+            if (args.length < 2) { sendPrefixed(sender, "cache-usage", "&eUsage: /skinview cache <get|clear> [joueur]"); return true; }
+            String sub = args[1].toLowerCase();
+            if ("get".equals(sub)) {
+                Player target = resolveTarget(sender, args, 2);
+                if (target == null) { sendPrefixed(sender, "player-not-found", "&cJoueur introuvable: %player%".replace("%player%", args.length > 2 ? args[2] : "?")); return true; }
+                boolean ok = plugin.skinService().applyFromStore(sender, target);
+                if (!ok) sendPrefixed(sender, "cache-miss", "&eAucune entrée de cache valide.");
+                return true;
+            } else if ("clear".equals(sub)) {
+                Player target = resolveTarget(sender, args, 2);
+                if (target == null) { sendPrefixed(sender, "player-not-found", "&cJoueur introuvable: %player%".replace("%player%", args.length > 2 ? args[2] : "?")); return true; }
+                plugin.skinService().clearCache(sender, target);
+                return true;
+            } else {
+                sendPrefixed(sender, "cache-usage", "&eUsage: /skinview cache <get|clear> [joueur]");
+                return true;
+            }
         }
 
         sendPrefixed(sender, "unknown-subcommand", "&cUnknown subcommand.");
         return true;
     }
 }
+

--- a/src/main/java/com/heneria/skinview/commands/SkinTabCompleter.java
+++ b/src/main/java/com/heneria/skinview/commands/SkinTabCompleter.java
@@ -13,12 +13,20 @@ public final class SkinTabCompleter implements TabCompleter {
         List<String> out = new ArrayList<>();
         if (args.length == 1) {
             out.add("help");
+            out.add("use");
+            out.add("url");
+            out.add("clear");
             if (sender.hasPermission("skinview.admin")) {
-                out.add("reload"); out.add("resolve");
+                out.add("reload");
+                out.add("resolve");
+                out.add("cache");
             }
         } else if (args.length == 2 && "resolve".equalsIgnoreCase(args[0]) && sender.hasPermission("skinview.admin")) {
             out.add("name"); out.add("url");
+        } else if (args.length == 2 && "cache".equalsIgnoreCase(args[0]) && sender.hasPermission("skinview.admin")) {
+            out.add("get"); out.add("clear");
         }
         return out;
     }
 }
+

--- a/src/main/java/com/heneria/skinview/listener/SkinAutoApplyJoinListener.java
+++ b/src/main/java/com/heneria/skinview/listener/SkinAutoApplyJoinListener.java
@@ -1,22 +1,16 @@
 package com.heneria.skinview.listener;
 
 import com.heneria.skinview.SkinviewPlugin;
-import com.heneria.skinview.service.SkinDescriptor;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
-/**
- * Spigot 1.21 — Auto-apply du skin premium au join (serveur offline).
- * - Résolution async par pseudo Mojang
- * - Application main-thread via PlayerProfile/PlayerTextures
- * - Aucun NMS, tick-safe
- */
+/** Auto-apply à partir du store puis fallback resolver (async) si nécessaire. */
 public final class SkinAutoApplyJoinListener implements Listener {
 
     private final SkinviewPlugin plugin;
@@ -28,28 +22,28 @@ public final class SkinAutoApplyJoinListener implements Listener {
     @EventHandler
     public void onJoin(PlayerJoinEvent e) {
         if (!plugin.getConfig().getBoolean("apply.update-on-join", true)) return;
+        final Player player = e.getPlayer();
+
+        // 1) Essayer le store (immédiat, main-thread)
+        boolean applied = plugin.skinService().applyFromStore(Bukkit.getConsoleSender(), player);
+        if (applied) return;
+
+        // 2) Fallback: resolver async par name si autorisé
         if (!plugin.getConfig().getBoolean("lookups.allow-premium-name", true)) return;
 
-        final Player player = e.getPlayer();
-        final String name = player.getName();
-
-        // Résolution async (ne JAMAIS bloquer le main thread)
-        CompletableFuture<SkinDescriptor> fut = plugin.resolver().resolveByPremiumName(name);
-        fut.whenComplete((sd, ex) -> {
+        String name = player.getName();
+        plugin.resolver().resolveByPremiumName(name).whenComplete((sd, ex) -> {
             if (ex != null) {
                 plugin.getLogger().log(Level.FINE, "[skinview] No premium skin for " + name + " (" + ex.getMessage() + ")");
-                return; // rien à faire si non-premium ou échec réseau
+                return;
             }
-            // Application main-thread
-              Bukkit.getScheduler().runTask(plugin, () -> {
-                  Player p = Bukkit.getPlayer(player.getUniqueId());
-                  if (p == null || !p.isOnline()) return;
-                  try {
-                      plugin.applier().apply(p, sd);
-                  } catch (Exception err) {
-                      plugin.getLogger().log(Level.WARNING, "[skinview] apply failed for " + name + ": " + err.getMessage(), err);
-                  }
-              });
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                try {
+                    plugin.skinService().applyByPremiumName(Bukkit.getConsoleSender(), player, name);
+                } catch (Exception err) {
+                    plugin.getLogger().log(Level.WARNING, "[skinview] apply failed for " + name + ": " + err.getMessage(), err);
+                }
+            });
         });
     }
 }

--- a/src/main/java/com/heneria/skinview/service/SkinService.java
+++ b/src/main/java/com/heneria/skinview/service/SkinService.java
@@ -1,0 +1,105 @@
+package com.heneria.skinview.service;
+
+import com.heneria.skinview.SkinviewPlugin;
+import com.heneria.skinview.store.SkinRecord;
+import com.heneria.skinview.store.SkinStore;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public final class SkinService {
+
+    private final SkinviewPlugin plugin;
+    private final SkinResolver resolver;
+    private final SkinApplier applier;
+    private final SkinStore store;
+
+    public SkinService(SkinviewPlugin plugin, SkinResolver resolver, SkinApplier applier, SkinStore store) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.resolver = Objects.requireNonNull(resolver, "resolver");
+        this.applier = Objects.requireNonNull(applier, "applier");
+        this.store = Objects.requireNonNull(store, "store");
+    }
+
+    public CompletableFuture<Void> applyByPremiumName(CommandSender actor, Player target, String name) {
+        final String targetName = target.getName();
+        info(actor, "apply-start", targetName);
+        return resolver.resolveByPremiumName(name)
+                .thenAccept(sd -> Bukkit.getScheduler().runTask(plugin, () -> {
+                    try {
+                        applier.apply(target, sd);
+                        store.put(target.getUniqueId(), sd);
+                        ok(actor, "apply-ok", targetName, sd.model().name());
+                    } catch (Exception e) {
+                        fail(actor, "apply-fail", e.getMessage());
+                    }
+                }))
+                .exceptionally(ex -> { fail(actor, "resolve-fail", ex.getMessage()); return null; });
+    }
+
+    public CompletableFuture<Void> applyByTexturesUrl(CommandSender actor, Player target, String url) {
+        final String targetName = target.getName();
+        info(actor, "apply-start", targetName);
+        return resolver.resolveByTexturesUrl(url)
+                .thenAccept(sd -> Bukkit.getScheduler().runTask(plugin, () -> {
+                    try {
+                        applier.apply(target, sd);
+                        store.put(target.getUniqueId(), sd);
+                        ok(actor, "apply-ok", targetName, sd.model().name());
+                    } catch (Exception e) {
+                        fail(actor, "apply-fail", e.getMessage());
+                    }
+                }))
+                .exceptionally(ex -> { fail(actor, "resolve-fail", ex.getMessage()); return null; });
+    }
+
+    /** Applique immédiatement à partir du store (si présent & TTL OK). */
+    public boolean applyFromStore(CommandSender actor, Player target) {
+        UUID id = target.getUniqueId();
+        var opt = store.get(id);
+        if (opt.isEmpty()) return false;
+        SkinRecord rec = opt.get();
+        SkinDescriptor sd = new SkinDescriptor(rec.skinUrl(), rec.model(), rec.texturesValueB64(), rec.texturesSignature());
+        try {
+            applier.apply(target, sd);
+            ok(actor, "apply-ok", target.getName(), sd.model().name());
+            return true;
+        } catch (Exception e) {
+            fail(actor, "apply-fail", e.getMessage());
+            return false;
+        }
+    }
+
+    public boolean clearCache(CommandSender actor, Player target) {
+        boolean ok = store.clear(target.getUniqueId());
+        if (ok) ok(actor, "clear-ok", target.getName(), null);
+        else fail(actor, "clear-fail", "not-found");
+        return ok;
+    }
+
+    /* helpers messages */
+    private void info(CommandSender s, String path, String player) {
+        send(s, path, player, null);
+    }
+    private void ok(CommandSender s, String path, String player, String model) {
+        send(s, path, player, model);
+    }
+    private void fail(CommandSender s, String path, String error) {
+        String msg = plugin.messages().getString(path, "&cErreur.");
+        msg = msg.replace("%error%", error == null ? "unknown" : error);
+        s.sendMessage(org.bukkit.ChatColor.translateAlternateColorCodes('&',
+                plugin.messages().getString("prefix", "") + msg));
+    }
+    private void send(CommandSender s, String path, String player, String model) {
+        String msg = plugin.messages().getString(path, "&7.");
+        if (player != null) msg = msg.replace("%player%", player);
+        if (model != null) msg = msg.replace("%model%", model);
+        s.sendMessage(org.bukkit.ChatColor.translateAlternateColorCodes('&',
+                plugin.messages().getString("prefix", "") + msg));
+    }
+}
+

--- a/src/main/java/com/heneria/skinview/store/SkinRecord.java
+++ b/src/main/java/com/heneria/skinview/store/SkinRecord.java
@@ -1,0 +1,34 @@
+package com.heneria.skinview.store;
+
+import com.heneria.skinview.service.SkinModel;
+
+import java.net.URI;
+import java.util.Objects;
+
+/** Entrée persistée du cache de skin. */
+public final class SkinRecord {
+    private final URI skinUrl;
+    private final SkinModel model;
+    private final String texturesValueB64;   // peut être null si source=URL
+    private final String texturesSignature;  // idem
+    private final long savedAtEpochSec;
+
+    public SkinRecord(URI skinUrl, SkinModel model, String texturesValueB64, String texturesSignature, long savedAtEpochSec) {
+        this.skinUrl = Objects.requireNonNull(skinUrl, "skinUrl");
+        this.model = Objects.requireNonNull(model, "model");
+        this.texturesValueB64 = texturesValueB64;
+        this.texturesSignature = texturesSignature;
+        this.savedAtEpochSec = savedAtEpochSec;
+    }
+
+    public URI skinUrl() { return skinUrl; }
+    public SkinModel model() { return model; }
+    public String texturesValueB64() { return texturesValueB64; }
+    public String texturesSignature() { return texturesSignature; }
+    public long savedAtEpochSec() { return savedAtEpochSec; }
+
+    public boolean hasSignedTextures() {
+        return texturesValueB64 != null && texturesSignature != null;
+    }
+}
+

--- a/src/main/java/com/heneria/skinview/store/SkinStore.java
+++ b/src/main/java/com/heneria/skinview/store/SkinStore.java
@@ -1,0 +1,14 @@
+package com.heneria.skinview.store;
+
+import com.heneria.skinview.service.SkinDescriptor;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SkinStore {
+    Optional<SkinRecord> get(UUID playerUuid);
+    void put(UUID playerUuid, SkinDescriptor descriptor);
+    boolean clear(UUID playerUuid);
+    long ttlSeconds();
+}
+

--- a/src/main/java/com/heneria/skinview/store/YamlSkinStore.java
+++ b/src/main/java/com/heneria/skinview/store/YamlSkinStore.java
@@ -1,0 +1,115 @@
+package com.heneria.skinview.store;
+
+import com.heneria.skinview.SkinviewPlugin;
+import com.heneria.skinview.service.SkinDescriptor;
+import com.heneria.skinview.service.SkinModel;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.scheduler.BukkitScheduler;
+
+import java.io.File;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class YamlSkinStore implements SkinStore {
+
+    private final SkinviewPlugin plugin;
+    private final File file;
+    private final long ttlSec;
+    private final ConcurrentHashMap<UUID, SkinRecord> cache = new ConcurrentHashMap<>();
+
+    public YamlSkinStore(SkinviewPlugin plugin) {
+        this.plugin = plugin;
+        File dataDir = new File(plugin.getDataFolder(), "data");
+        if (!dataDir.exists()) dataDir.mkdirs();
+        String path = plugin.getConfig().getString("storage.file", "data/skins.yml");
+        this.file = new File(plugin.getDataFolder(), path);
+        this.ttlSec = Math.max(300, plugin.getConfig().getLong("storage.ttl-seconds", 86400));
+        load();
+    }
+
+    @Override
+    public Optional<SkinRecord> get(UUID playerUuid) {
+        SkinRecord rec = cache.get(playerUuid);
+        if (rec == null) return Optional.empty();
+        long ageSec = Instant.now().getEpochSecond() - rec.savedAtEpochSec();
+        if (ageSec > ttlSec) {
+            cache.remove(playerUuid);
+            return Optional.empty();
+        }
+        return Optional.of(rec);
+    }
+
+    @Override
+    public void put(UUID playerUuid, SkinDescriptor descriptor) {
+        SkinRecord rec = new SkinRecord(
+                descriptor.skinUrl(),
+                descriptor.model(),
+                descriptor.texturesValueB64(),
+                descriptor.texturesSignature(),
+                Instant.now().getEpochSecond()
+        );
+        cache.put(playerUuid, rec);
+        saveAsync();
+    }
+
+    @Override
+    public boolean clear(UUID playerUuid) {
+        boolean removed = cache.remove(playerUuid) != null;
+        if (removed) saveAsync();
+        return removed;
+    }
+
+    @Override
+    public long ttlSeconds() { return ttlSec; }
+
+    /* ====== I/O YAML ====== */
+
+    private void load() {
+        if (!file.exists()) return;
+        FileConfiguration yml = YamlConfiguration.loadConfiguration(file);
+        if (!yml.isConfigurationSection("players")) return;
+        for (String k : yml.getConfigurationSection("players").getKeys(false)) {
+            try {
+                UUID uuid = UUID.fromString(k);
+                String url = yml.getString("players." + k + ".url");
+                String model = yml.getString("players." + k + ".model", "STEVE");
+                String value = yml.getString("players." + k + ".textures.value");
+                String sig = yml.getString("players." + k + ".textures.signature");
+                long saved = yml.getLong("players." + k + ".savedAt", 0L);
+                if (url == null || saved <= 0) continue;
+                SkinRecord rec = new SkinRecord(URI.create(url), SkinModel.valueOf(model), value, sig, saved);
+                cache.put(uuid, rec);
+            } catch (Exception ignored) {}
+        }
+    }
+
+    private void saveAsync() {
+        BukkitScheduler sch = plugin.getServer().getScheduler();
+        sch.runTaskAsynchronously(plugin, this::saveNow);
+    }
+
+    private synchronized void saveNow() {
+        try {
+            YamlConfiguration yml = new YamlConfiguration();
+            for (var e : cache.entrySet()) {
+                String base = "players." + e.getKey();
+                SkinRecord r = e.getValue();
+                yml.set(base + ".url", r.skinUrl().toString());
+                yml.set(base + ".model", r.model().name());
+                yml.set(base + ".savedAt", r.savedAtEpochSec());
+                if (r.hasSignedTextures()) {
+                    yml.set(base + ".textures.value", r.texturesValueB64());
+                    yml.set(base + ".textures.signature", r.texturesSignature());
+                }
+            }
+            yml.save(file);
+        } catch (Exception ex) {
+            plugin.getLogger().warning("[skinview] Save store failed: " + ex.getMessage());
+        }
+    }
+}
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,8 +1,5 @@
-# skinview — configuration par défaut
-# Rappel: le dépôt doit rester 100% TEXTE (pas de binaires).
-
 apply:
-  update-on-join: true        # sera utilisé aux tickets suivants
+  update-on-join: true
   refresh-tablist: true
   protocollib-enable: true
 
@@ -15,5 +12,8 @@ lookups:
   allow-textures-url: true
   allow-unsigned: true
 
-logging:
-  level: INFO
+storage:
+  type: YAML
+  file: "data/skins.yml"
+  ttl-seconds: 86400  # 24h
+

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -6,6 +6,11 @@ help:
   - "&e/skinview reload &7: Recharge la configuration & messages &8(perm: skinview.admin)"
   - "&e/skinview resolve name <Premium> &7: Teste la résolution Mojang &8(perm: skinview.admin)"
   - "&e/skinview resolve url <textures.minecraft.net/...> &7: Teste la résolution par URL &8(perm: skinview.admin)"
+  - "&e/skinview use <Premium> [joueur] &7: Applique un skin premium"
+  - "&e/skinview url <textures.minecraft.net/...> [joueur] &7: Applique par URL textures"
+  - "&e/skinview clear [joueur] &7: Vide le cache du joueur"
+  - "&e/skinview cache get [joueur] &7: Tente l'apply depuis le cache &8(perm: skinview.admin)"
+  - "&e/skinview cache clear [joueur] &7: Efface l'entrée du cache &8(perm: skinview.admin)"
 
 reloaded: "&aConfiguration rechargée."
 no-permission: "&cVous n'avez pas la permission."
@@ -13,4 +18,17 @@ unknown-subcommand: "&cSous-commande inconnue. &7Essayez &e/skinview help&7."
 
 resolve-usage: "&eUsage: /skinview resolve <name|url> <value>"
 resolve-started: "&7Résolution en cours..."
-resolve-fail: "&cÉchec de résolution."
+resolve-fail: "&cÉchec de résolution: %error%"
+
+apply-start: "&7Application du skin à &f%player%&7..."
+apply-ok: "&aSkin appliqué à &f%player%&7 (&f%model%&7)."
+apply-fail: "&cÉchec application skin: %error%"
+
+clear-ok: "&aCache vidé pour &f%player%&7."
+clear-fail: "&cAucune entrée à effacer: %error%"
+
+player-not-found: "&cJoueur introuvable: &f%player%&7."
+invalid-arg: "&cArguments invalides."
+cache-usage: "&eUsage: /skinview cache <get|clear> [joueur]"
+cache-miss: "&eAucune entrée de cache valide."
+


### PR DESCRIPTION
## Summary
- persist skins in `YamlSkinStore` and reapply from cache at join
- expose `applyFromStore` and add admin `/skinview cache` subcommands
- document new storage options and YAML persistence

## Testing
- `gradle clean check`
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_689defa1e2188324b8256953107b2761